### PR TITLE
chore: désactiver react/prop-types pour les projets TS

### DIFF
--- a/packages/eslint-config/react-internal.js
+++ b/packages/eslint-config/react-internal.js
@@ -21,6 +21,7 @@ export const config = [
         rules: {
             ...pluginReactHooks.configs.recommended.rules,
             "react/react-in-jsx-scope": "off",
+            "react/prop-types": "off",
         },
         languageOptions: {
             globals: {


### PR DESCRIPTION
## Résumé
- désactive la règle `react/prop-types` dans la configuration React interne pour éviter les faux positifs sur les composants TypeScript

## Tests
- yarn lint *(échoue : erreurs existantes @typescript-eslint/no-unsafe-argument et associées)*

------
https://chatgpt.com/codex/tasks/task_e_68cd630a0f8083249928a68bcab993d0