### PR TITLE
Fix unnecessary event assertions for navigation linting

### DIFF
--- a/apps/desktop/src/features/navigation/components/navInput/RenderInput.tsx
+++ b/apps/desktop/src/features/navigation/components/navInput/RenderInput.tsx
@@ -58,7 +58,7 @@ const RenderInput: React.FC<RenderInputProps> = ({
                             onKeyDown={(e) => {
                                 if (e.key === "Enter") {
                                     e.preventDefault();
-                                    handleSubmit(e as React.KeyboardEvent<HTMLInputElement>);
+                                    handleSubmit(e);
                                 }
                             }}
                             className={`nav-link ${getShowClass(

--- a/apps/desktop/src/features/navigation/components/navLink/SubMenu.tsx
+++ b/apps/desktop/src/features/navigation/components/navLink/SubMenu.tsx
@@ -29,7 +29,7 @@ const SubMenu: React.FC<SubMenuProps> = ({ menuItem, isOpen, onSubItemClick, tri
         subItemScrollOffset: number | undefined,
         e: React.MouseEvent | React.KeyboardEvent
     ) => {
-        if ("button" in e && isModifiedClick(e as React.MouseEvent)) return;
+        if ("button" in e && isModifiedClick(e)) return;
 
         e.preventDefault();
         e.stopPropagation();

--- a/apps/mobile/src/utils/sections.ts
+++ b/apps/mobile/src/utils/sections.ts
@@ -1,4 +1,3 @@
-/* eslint-disable-next-line */
 export let currentSectionId = "";
 
 export function scrollInView(sections: { id: string }[]) {


### PR DESCRIPTION
## Summary
- rely on the existing mouse-event guard in `SubMenu` instead of casting
- remove the keyboard event cast when submitting the search input
- drop an unused eslint-disable directive that triggered a lint warning

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68cd6899cdec8324a80e32838f51d436