### PR TITLE
Add sync scripts and tsx dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,11 @@
         "keep": "yarn lint && node ./tools/scripts/keep-list.cjs && node ./tools/scripts/keep-functions.cjs",
         "keep:fn": "node /tools/scripts/keep-functions.cjs",
         "css:prune": "tsx tools/scripts/css-prune.ts",
-        "css:prune:apply": "tsx tools/scripts/css-prune.ts --apply"
+        "css:prune:apply": "tsx tools/scripts/css-prune.ts --apply",
+        "sync:admin": "tsx tooling/sync-public.ts --app=admin",
+        "sync:desktop": "tsx tooling/sync-public.ts --app=desktop",
+        "sync:mobile": "tsx tooling/sync-public.ts --app=mobile",
+        "sync:main": "tsx tooling/sync-public.ts --app=main"
     },
     "devDependencies": {
         "@eslint/js": "9.35.0",
@@ -49,6 +53,7 @@
         "globals": "16.3.0",
         "rimraf": "^6.0.1",
         "turbo": "^2.5.6",
+        "tsx": "^4.16.0",
         "typescript": "^5.9.2",
         "typescript-eslint": "^8.44.0"
     },


### PR DESCRIPTION
## Summary
- add the tsx dev dependency at the root so tooling scripts can run
- add sync scripts for the admin, desktop, mobile, and main apps
- confirm the workspace patterns still include apps/* and packages/*

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1061115588324953255673ee2d640