### PR TITLE
[Feat] Préparer les assets publics avant dev/build

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -3,8 +3,9 @@
     "version": "0.1.0",
     "private": true,
     "scripts": {
-        "dev": "next dev -p 3003",
-        "build": "next build",
+        "prepare:public": "tsx ../../tooling/sync-public.ts --app=admin",
+        "dev": "yarn run prepare:public && next dev -p 3003",
+        "build": "yarn run prepare:public && next build",
         "start": "next start -p 3003",
         "lint": "next lint",
         "typecheck": "tsc --noEmit --pretty false --skipLibCheck -p tsconfig.json",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -3,8 +3,9 @@
     "version": "0.1.0",
     "private": true,
     "scripts": {
-        "dev": "next dev -p 3001",
-        "build": "next build",
+        "prepare:public": "tsx ../../tooling/sync-public.ts --app=desktop",
+        "dev": "yarn run prepare:public && next dev -p 3001",
+        "build": "yarn run prepare:public && next build",
         "start": "next start -p 3001",
         "lint": "next lint",
         "typecheck": "tsc --noEmit --pretty false --skipLibCheck -p tsconfig.json",

--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -3,8 +3,9 @@
     "version": "0.1.0",
     "private": true,
     "scripts": {
-        "dev": "next dev -p 3000",
-        "build": "next build",
+        "prepare:public": "tsx ../../tooling/sync-public.ts --app=main",
+        "dev": "yarn run prepare:public && next dev -p 3000",
+        "build": "yarn run prepare:public && next build",
         "start": "next start -p 3000",
         "lint": "next lint",
         "typecheck": "tsc --noEmit --pretty false --skipLibCheck -p tsconfig.json",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -3,8 +3,9 @@
     "version": "0.1.0",
     "private": true,
     "scripts": {
-        "dev": "next dev -p 3002",
-        "build": "next build",
+        "prepare:public": "tsx ../../tooling/sync-public.ts --app=mobile",
+        "dev": "yarn run prepare:public && next dev -p 3002",
+        "build": "yarn run prepare:public && next build",
         "start": "next start -p 3002",
         "lint": "next lint",
         "typecheck": "tsc --noEmit --pretty false --skipLibCheck -p tsconfig.json",


### PR DESCRIPTION
## Description
- ajoute le script `prepare:public` dans les apps admin, desktop, mobile et main
- exécute automatiquement la synchronisation avant `yarn dev` et `yarn build`

## Tests effectués
- non exécutés (non requis)


------
https://chatgpt.com/codex/tasks/task_e_68d1085718a8832483f482ff6201b427