### PR TITLE
Add prepare public step to turbo pipeline

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -11,14 +11,18 @@
     "tasks": {
         "dev": {
             "cache": false,
-            "persistent": true
+            "persistent": true,
+            "dependsOn": ["^prepare:public"]
         },
         "start": {
             "cache": false,
             "persistent": true
         },
+        "prepare:public": {
+            "cache": false
+        },
         "build": {
-            "dependsOn": ["^build"],
+            "dependsOn": ["^prepare:public", "^build"],
             "outputs": [
                 ".next/**",
                 "dist/**",


### PR DESCRIPTION
## Summary
- add a `prepare:public` task to the Turbo pipeline with caching disabled
- make the `dev` and `build` tasks depend on the new prepare step while keeping existing outputs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d10a16bcf883248b9006944a5ee360