### PR TITLE
Fix: préparer les builds Amplify avec prepare:public

### DIFF
--- a/apps/desktop/amplify.yml
+++ b/apps/desktop/amplify.yml
@@ -12,6 +12,7 @@ frontend:
         build:
             commands:
                 - export NEXT_TELEMETRY_DISABLED=1
+                - yarn run prepare:public
                 - yarn build
     artifacts:
         baseDirectory: .next

--- a/apps/main/amplify.yml
+++ b/apps/main/amplify.yml
@@ -12,6 +12,7 @@ frontend:
         build:
             commands:
                 - export NEXT_TELEMETRY_DISABLED=1
+                - yarn run prepare:public
                 - yarn build
     artifacts:
         baseDirectory: .next

--- a/apps/mobile/amplify.yml
+++ b/apps/mobile/amplify.yml
@@ -12,6 +12,7 @@ frontend:
         build:
             commands:
                 - export NEXT_TELEMETRY_DISABLED=1
+                - yarn run prepare:public
                 - yarn build
     artifacts:
         baseDirectory: .next


### PR DESCRIPTION
## Résumé
- ajoute l'étape `yarn run prepare:public` dans les builds Amplify desktop, mobile et main
- garantit que la génération des assets publics précède `yarn build`

## Tests
- yarn install

------
https://chatgpt.com/codex/tasks/task_e_68d118ce571c8324875304d0ad65d8f8