### PR TITLE
[Fix] Sécuriser redirects et sync public

### DIFF
--- a/apps/main/next.config.ts
+++ b/apps/main/next.config.ts
@@ -1,5 +1,41 @@
 import type { NextConfig } from "next";
 
+type Redirect = {
+    source: `/${string}`;
+    destination: `/${string}`;
+    permanent?: boolean;
+    basePath?: boolean;
+    locale?: boolean;
+};
+
+type Rewrite = {
+    source: `/${string}`;
+    destination: `/${string}`;
+    basePath?: boolean;
+    locale?: boolean;
+};
+
+const notSelf = <T extends { source: string; destination: string }>(rule: T): boolean => {
+    const normalize = (value: string): string => value.replace(/\/+$/, "") || "/";
+    return normalize(rule.source) !== normalize(rule.destination);
+};
+
+const withSafeRedirects = async (): Promise<Redirect[]> => {
+    const redirects: Redirect[] = [
+        // Ajoutez vos redirections ici.
+    ];
+
+    return redirects.filter(notSelf);
+};
+
+const withSafeRewrites = async (): Promise<Rewrite[]> => {
+    const rewrites: Rewrite[] = [
+        // Ajoutez vos réécritures ici.
+    ];
+
+    return rewrites.filter(notSelf);
+};
+
 const nextConfig: NextConfig = {
     experimental: {},
 
@@ -45,6 +81,14 @@ const nextConfig: NextConfig = {
                 ],
             },
         ];
+    },
+
+    async redirects() {
+        return withSafeRedirects();
+    },
+
+    async rewrites() {
+        return withSafeRewrites();
     },
 };
 


### PR DESCRIPTION
## Summary
- empêche les redirections/réécritures auto-référencées dans `apps/main`
- fiabilise `tooling/sync-public.ts` (détection racine, garde src==dest, logs)

## Testing
- yarn
- yarn turbo prune --scope=main --no-dedupe >/dev/null 2>&1 || true
- yarn workspace main run prepare:public
- CI=1 yarn workspace main run build
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68d12334e18883248e92c0fe3a765179