### PR TITLE
[ui] Prépare l'ossature de la navigation mobile partagée

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,1 +1,6 @@
 export type { AuthUser, AuthRule, AuthAllow } from "./auth";
+export type {
+    NavigationMenuItem,
+    NavigationMenuLinks,
+    NavigationSubItem,
+} from "./navigation/menu";

--- a/packages/types/src/navigation/menu.ts
+++ b/packages/types/src/navigation/menu.ts
@@ -1,0 +1,23 @@
+export interface NavigationSubItem {
+    id: string;
+    title: string;
+    AnchorId: string;
+    class: string;
+}
+
+export interface NavigationMenuItem {
+    id: string;
+    title: string;
+    path: string;
+    svg: string;
+    class?: string;
+    AnchorId?: string;
+    subItems?: NavigationSubItem[];
+}
+
+export interface NavigationMenuLinks {
+    mainLink: NavigationMenuItem[];
+    search?: NavigationMenuItem[];
+    reservation?: NavigationMenuItem[];
+    connection?: NavigationMenuItem[];
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./MarkdownViewer";
 export * from "./auth";
+export * from "./navigation";

--- a/packages/ui/src/navigation/README.md
+++ b/packages/ui/src/navigation/README.md
@@ -1,0 +1,16 @@
+# Navigation mobile partagée (squelette)
+
+Ce dossier centralise la future implémentation de la navigation mobile mutualisée.
+Les fichiers sont volontairement vides pour l'instant : ils servent d'ossature afin
+de préparer la migration depuis `apps/mobile`.
+
+## Répartition prévue
+
+- `core/contexts` : `NavigationContext` et `ScrollContext` + helper `createUseContext`.
+- `core/hooks` : hooks côté UI (`useSmoothScroll`, `useInitialScroll`, etc.).
+- `core/utils` : helpers DOM (handlers, navigation, scroll).
+- `core/workers` : workers Web pour le scroll.
+- `mobile/` : composants, icônes et composition du header mobile.
+
+Chaque fichier contient un commentaire `TODO` indiquant la source mobile
+à déplacer lors de l'étape suivante.

--- a/packages/ui/src/navigation/core/contexts/NavigationContext.tsx
+++ b/packages/ui/src/navigation/core/contexts/NavigationContext.tsx
@@ -1,0 +1,2 @@
+// TODO: déplacer NavigationContext depuis apps/mobile/src/utils/context/NavigationContext.tsx
+export {};

--- a/packages/ui/src/navigation/core/contexts/ScrollContext.tsx
+++ b/packages/ui/src/navigation/core/contexts/ScrollContext.tsx
@@ -1,0 +1,2 @@
+// TODO: déplacer ScrollContext depuis apps/mobile/src/utils/context/ScrollContext.tsx
+export {};

--- a/packages/ui/src/navigation/core/contexts/index.ts
+++ b/packages/ui/src/navigation/core/contexts/index.ts
@@ -1,0 +1,2 @@
+// Contexte de navigation mobile (NavigationProvider) et ScrollProvider seront migrés ici.
+export {};

--- a/packages/ui/src/navigation/core/hooks/index.ts
+++ b/packages/ui/src/navigation/core/hooks/index.ts
@@ -1,0 +1,2 @@
+// TODO: exposer les hooks partagés (useSmoothScroll, useInitialScroll, useNavigationState, ...)
+export {};

--- a/packages/ui/src/navigation/core/hooks/useInitialScroll.ts
+++ b/packages/ui/src/navigation/core/hooks/useInitialScroll.ts
@@ -1,0 +1,2 @@
+// TODO: déplacer useInitialScroll depuis apps/mobile/src/utils/scrollUtils.ts
+export {};

--- a/packages/ui/src/navigation/core/hooks/useSmoothScroll.ts
+++ b/packages/ui/src/navigation/core/hooks/useSmoothScroll.ts
@@ -1,0 +1,2 @@
+// TODO: déplacer useSmoothScroll depuis apps/mobile/src/utils/useSmoothScroll.ts
+export {};

--- a/packages/ui/src/navigation/core/index.ts
+++ b/packages/ui/src/navigation/core/index.ts
@@ -1,0 +1,4 @@
+export * from "./contexts";
+export * from "./hooks";
+export * from "./utils";
+export * from "./workers";

--- a/packages/ui/src/navigation/core/utils/createUseContext.tsx
+++ b/packages/ui/src/navigation/core/utils/createUseContext.tsx
@@ -1,0 +1,2 @@
+// TODO: déplacer createUseContext depuis apps/mobile/src/utils/context/utils/createUseContext.tsx
+export {};

--- a/packages/ui/src/navigation/core/utils/handlers.ts
+++ b/packages/ui/src/navigation/core/utils/handlers.ts
@@ -1,0 +1,2 @@
+// TODO: déplacer handlers depuis apps/mobile/src/utils/handlers.ts
+export {};

--- a/packages/ui/src/navigation/core/utils/index.ts
+++ b/packages/ui/src/navigation/core/utils/index.ts
@@ -1,0 +1,2 @@
+// TODO: regrouper les utilitaires (handlers, nav, scrollSmooth, createUseContext, ...)
+export {};

--- a/packages/ui/src/navigation/core/utils/nav.ts
+++ b/packages/ui/src/navigation/core/utils/nav.ts
@@ -1,0 +1,2 @@
+// TODO: déplacer handleNavClick depuis apps/mobile/src/utils/nav.ts
+export {};

--- a/packages/ui/src/navigation/core/utils/scrollSmooth.ts
+++ b/packages/ui/src/navigation/core/utils/scrollSmooth.ts
@@ -1,0 +1,2 @@
+// TODO: déplacer handleScrollClick depuis apps/mobile/src/utils/scrollSmooth.ts
+export {};

--- a/packages/ui/src/navigation/core/workers/index.ts
+++ b/packages/ui/src/navigation/core/workers/index.ts
@@ -1,0 +1,2 @@
+// TODO: déplacer les workers de scroll (scrollWorker, scrollSmoothWorker) ici.
+export {};

--- a/packages/ui/src/navigation/core/workers/scrollSmoothWorker.d.ts
+++ b/packages/ui/src/navigation/core/workers/scrollSmoothWorker.d.ts
@@ -1,0 +1,2 @@
+// TODO: déplacer apps/mobile/src/workers/scrollSmoothWorker.d.ts ici.
+export {};

--- a/packages/ui/src/navigation/core/workers/scrollSmoothWorker.js
+++ b/packages/ui/src/navigation/core/workers/scrollSmoothWorker.js
@@ -1,0 +1,1 @@
+// TODO: déplacer apps/mobile/src/workers/scrollSmoothWorker.js ici.

--- a/packages/ui/src/navigation/core/workers/scrollWorker.d.ts
+++ b/packages/ui/src/navigation/core/workers/scrollWorker.d.ts
@@ -1,0 +1,2 @@
+// TODO: déplacer apps/mobile/src/workers/scrollWorker.d.ts ici.
+export {};

--- a/packages/ui/src/navigation/core/workers/scrollWorker.js
+++ b/packages/ui/src/navigation/core/workers/scrollWorker.js
@@ -1,0 +1,1 @@
+// TODO: déplacer apps/mobile/src/workers/scrollWorker.js ici.

--- a/packages/ui/src/navigation/index.ts
+++ b/packages/ui/src/navigation/index.ts
@@ -1,0 +1,2 @@
+export * from "./core";
+export * from "./mobile";

--- a/packages/ui/src/navigation/mobile/components/ButtonOpen.tsx
+++ b/packages/ui/src/navigation/mobile/components/ButtonOpen.tsx
@@ -1,0 +1,2 @@
+// TODO: migrer ButtonOpen depuis apps/mobile/src/components/header/ButtonOpen.tsx
+export {};

--- a/packages/ui/src/navigation/mobile/components/Header.tsx
+++ b/packages/ui/src/navigation/mobile/components/Header.tsx
@@ -1,0 +1,2 @@
+// TODO: migrer Header depuis apps/mobile/src/components/header/Header.tsx
+export {};

--- a/packages/ui/src/navigation/mobile/components/HeaderLazy.tsx
+++ b/packages/ui/src/navigation/mobile/components/HeaderLazy.tsx
@@ -1,0 +1,2 @@
+// TODO: migrer HeaderLazy depuis apps/mobile/src/components/header/HeaderLazy.tsx
+export {};

--- a/packages/ui/src/navigation/mobile/components/LogoLink.tsx
+++ b/packages/ui/src/navigation/mobile/components/LogoLink.tsx
@@ -1,0 +1,2 @@
+// TODO: migrer LogoLink depuis apps/mobile/src/components/header/LogoLink.tsx
+export {};

--- a/packages/ui/src/navigation/mobile/components/MenuList.tsx
+++ b/packages/ui/src/navigation/mobile/components/MenuList.tsx
@@ -1,0 +1,2 @@
+// TODO: migrer MenuList depuis apps/mobile/src/components/header/MenuList.tsx
+export {};

--- a/packages/ui/src/navigation/mobile/components/MenuOpen.tsx
+++ b/packages/ui/src/navigation/mobile/components/MenuOpen.tsx
@@ -1,0 +1,2 @@
+// TODO: migrer MenuOpen depuis apps/mobile/src/components/header/MenuOpen.tsx
+export {};

--- a/packages/ui/src/navigation/mobile/components/Nav.tsx
+++ b/packages/ui/src/navigation/mobile/components/Nav.tsx
@@ -1,0 +1,2 @@
+// TODO: migrer Nav depuis apps/mobile/src/components/header/Nav.tsx
+export {};

--- a/packages/ui/src/navigation/mobile/components/NavLink.tsx
+++ b/packages/ui/src/navigation/mobile/components/NavLink.tsx
@@ -1,0 +1,2 @@
+// TODO: migrer NavLink depuis apps/mobile/src/components/header/NavLink.tsx
+export {};

--- a/packages/ui/src/navigation/mobile/components/SubMenu.tsx
+++ b/packages/ui/src/navigation/mobile/components/SubMenu.tsx
@@ -1,0 +1,2 @@
+// TODO: migrer SubMenu depuis apps/mobile/src/components/header/SubMenu.tsx
+export {};

--- a/packages/ui/src/navigation/mobile/components/index.ts
+++ b/packages/ui/src/navigation/mobile/components/index.ts
@@ -1,0 +1,2 @@
+// TODO: ré-exporter les composants de menu mobile.
+export {};

--- a/packages/ui/src/navigation/mobile/icons/Blog.tsx
+++ b/packages/ui/src/navigation/mobile/icons/Blog.tsx
@@ -1,0 +1,2 @@
+// TODO: migrer Blog depuis apps/mobile/src/components/svg_Icon/Blog.tsx
+export {};

--- a/packages/ui/src/navigation/mobile/icons/Contact.tsx
+++ b/packages/ui/src/navigation/mobile/icons/Contact.tsx
@@ -1,0 +1,2 @@
+// TODO: migrer Contact depuis apps/mobile/src/components/svg_Icon/Contact.tsx
+export {};

--- a/packages/ui/src/navigation/mobile/icons/Home.tsx
+++ b/packages/ui/src/navigation/mobile/icons/Home.tsx
@@ -1,0 +1,2 @@
+// TODO: migrer Home depuis apps/mobile/src/components/svg_Icon/Home.tsx
+export {};

--- a/packages/ui/src/navigation/mobile/icons/Logo.tsx
+++ b/packages/ui/src/navigation/mobile/icons/Logo.tsx
@@ -1,0 +1,2 @@
+// TODO: migrer Logo depuis apps/mobile/src/components/svg_Icon/Logo.tsx
+export {};

--- a/packages/ui/src/navigation/mobile/icons/MenuIcon.tsx
+++ b/packages/ui/src/navigation/mobile/icons/MenuIcon.tsx
@@ -1,0 +1,2 @@
+// TODO: migrer MenuIcon depuis apps/mobile/src/components/svg_Icon/utils/MenuIcon.tsx
+export {};

--- a/packages/ui/src/navigation/mobile/icons/Services.tsx
+++ b/packages/ui/src/navigation/mobile/icons/Services.tsx
@@ -1,0 +1,2 @@
+// TODO: migrer Services depuis apps/mobile/src/components/svg_Icon/Services.tsx
+export {};

--- a/packages/ui/src/navigation/mobile/icons/Tarifs.tsx
+++ b/packages/ui/src/navigation/mobile/icons/Tarifs.tsx
@@ -1,0 +1,2 @@
+// TODO: migrer Tarifs depuis apps/mobile/src/components/svg_Icon/Tarifs.tsx
+export {};

--- a/packages/ui/src/navigation/mobile/icons/index.ts
+++ b/packages/ui/src/navigation/mobile/icons/index.ts
@@ -1,0 +1,2 @@
+// TODO: ré-exporter les icônes du menu mobile.
+export {};

--- a/packages/ui/src/navigation/mobile/index.ts
+++ b/packages/ui/src/navigation/mobile/index.ts
@@ -1,0 +1,2 @@
+// TODO: exposer les composants de navigation mobile (Header, Nav, ...).
+export {};

--- a/packages/ui/src/navigation/mobile/svgComponents.ts
+++ b/packages/ui/src/navigation/mobile/svgComponents.ts
@@ -1,0 +1,2 @@
+// TODO: migrer svgComponents depuis apps/mobile/src/components/header/svgComponents.ts
+export {};


### PR DESCRIPTION
## Summary
- expose un nouveau dossier `packages/ui/src/navigation` avec les sous-domaines `core` et `mobile`
- ajoute des fichiers squelette (avec TODO) pour contextes, hooks, utilitaires, workers et composants de navigation mobile
- publie les types de menu/navigation dans `packages/types` pour préparer leur partage

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68d266f2fe488324ad8084c54affc110